### PR TITLE
chore: bump toolchain to SDK 37 + common-utils 1.0.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,11 +14,11 @@ fun com.android.build.api.dsl.ApplicationBuildType.addConstant(name: String, val
 
 android {
     namespace = "de.lemke.sudoku"
-    compileSdk = 36
+    compileSdk = 37
     defaultConfig {
         applicationId = "de.lemke.sudoku"
         minSdk = 26
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 62
         versionName = "3.5.6"
     }
@@ -66,6 +66,8 @@ android {
     packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
 }
 dependencies {
+    implementation(libs.oneui.design)
+    implementation(libs.oneui.icons)
     implementation(libs.common.utils)
     implementation(libs.datastore.preferences)
     implementation(libs.async.layout.inflater)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,9 @@ subprojects {
                 sourceCompatibility = JavaVersion.VERSION_21
                 targetCompatibility = JavaVersion.VERSION_21
             }
-            configurations.all {
+            // Apply AndroidX exclusions ONLY to production configurations.
+            // androidTest* and test* configs need genuine AOSP AndroidX modules.
+            configurations.matching { !it.name.contains("test", ignoreCase = true) }.configureEach {
                 exclude(group = "androidx.core", module = "core")
                 exclude(group = "androidx.core", module = "core-ktx")
                 exclude(group = "androidx.customview", module = "customview")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 aboutlibraries = "14.2.0"
 async-layout-inflater = "1.1.0"
 bundler = "1.0.4"
-common-utils = "0.9.22"
+common-utils = "1.0.0"
 datastore-preferences = "1.2.1"
 documentfile = "1.1.0"
 gradle = "9.2.1"
@@ -11,6 +11,8 @@ json-kotlin-schema = "0.57"
 kjson = "9.10"
 kotlin = "2.3.21"
 ksp = "2.3.8"
+oneui-design = "0.9.11+oneui8"
+oneui-icons = "1.1.0"
 play-services-games = "21.0.0"
 room = "2.8.4"
 sudoku = "5.3.0"
@@ -25,6 +27,8 @@ hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt"
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 json-kotlin-schema = { module = "net.pwall.json:json-kotlin-schema", version.ref = "json-kotlin-schema" }
 kjson = { module = "io.kjson:kjson", version.ref = "kjson" }
+oneui-design = { module = "io.github.tribalfs:oneui-design", version.ref = "oneui-design" }
+oneui-icons = { module = "io.github.oneuiproject:icons", version.ref = "oneui-icons" }
 play-services-games = { module = "com.google.android.gms:play-services-games-v2", version.ref = "play-services-games" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }


### PR DESCRIPTION
## Summary
- compileSdk/targetSdk 36 → 37 (Android 17)
- common-utils 0.9.22 → 1.0.0
- Add explicit `oneui-design 0.9.11+oneui8` and `oneui-icons 1.1.0` deps (required by common-utils 1.0.0)
- Scope AndroidX exclusions to production-only configs — fixes Hilt KSP class hierarchy resolution for test tooling

## Test plan
- [x] `./gradlew assembleDebug` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)