### PR TITLE
refactor: preference key binding convention (Phase 5)

### DIFF
--- a/app/src/main/java/de/lemke/sudoku/data/UserSettings.kt
+++ b/app/src/main/java/de/lemke/sudoku/data/UserSettings.kt
@@ -19,6 +19,7 @@ package de.lemke.sudoku.data
 import android.content.SharedPreferences
 import de.lemke.commonutils.data.SettingsRepository
 import de.lemke.commonutils.data.delegates
+import de.lemke.commonutils.data.mapped
 import de.lemke.commonutils.data.sanitized
 import de.lemke.sudoku.domain.model.Difficulty
 import de.lemke.sudoku.domain.model.SudokuFilterFlags.DIFFICULTY_ALL
@@ -38,7 +39,10 @@ class UserSettings(
     var animationsEnabled: Boolean by preferences.delegates.boolean(true)
     var highlightRegional: Boolean by preferences.delegates.boolean(true)
     var highlightNumber: Boolean by preferences.delegates.boolean(true)
-    var errorLimit: Int by preferences.delegates.int(3).sanitized { it.coerceAtLeast(0) }
+    var errorLimit: Int by preferences.delegates
+        .string("3")
+        .mapped(to = { it.toIntOrNull() ?: 0 }, from = Int::toString)
+        .sanitized { it.coerceAtLeast(0) }
     var filterFlags: Int by preferences.delegates.int(TYPE_ALL or SIZE_ALL or DIFFICULTY_ALL)
     var dailyShowUncompleted: Boolean by preferences.delegates.boolean(true)
     var dailySudokuNotificationEnabled: Boolean by preferences.delegates.boolean(true)

--- a/app/src/main/java/de/lemke/sudoku/ui/SettingsActivity.kt
+++ b/app/src/main/java/de/lemke/sudoku/ui/SettingsActivity.kt
@@ -167,10 +167,9 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun initErrorLimitPreference() {
-            findPreference<DropDownPreference>("error_limit_pref")?.apply {
-                summary = if (viewModel.errorLimit == 0) getString(R.string.no_limit) else viewModel.errorLimit.toString()
+            findPreference<DropDownPreference>("errorLimit")?.apply {
+                summary = if (userSettings.errorLimit == 0) getString(R.string.no_limit) else userSettings.errorLimit.toString()
                 onNewValue { newValue: String ->
-                    viewModel.errorLimit = newValue.toIntOrNull() ?: 0
                     summary = if (newValue.toIntOrNull() == 0) getString(R.string.no_limit) else newValue
                 }
             } ?: Log.e(TAG, "error limit Preference not found")

--- a/app/src/main/java/de/lemke/sudoku/ui/SettingsActivity.kt
+++ b/app/src/main/java/de/lemke/sudoku/ui/SettingsActivity.kt
@@ -47,7 +47,6 @@ import androidx.preference.DropDownPreference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceScreen
 import androidx.preference.SeslSwitchPreferenceScreen
-import androidx.preference.SwitchPreferenceCompat
 import com.google.android.gms.games.PlayGames
 import dagger.hilt.android.AndroidEntryPoint
 import de.lemke.commonutils.ui.utils.initCommonUtilsPreferences
@@ -111,7 +110,8 @@ class SettingsActivity : AppCompatActivity() {
         private val requestPermissionLauncher =
             registerForActivityResult(RequestPermission()) { isGranted: Boolean ->
                 viewModel.onNotificationPermissionResult(isGranted)
-                findPreference<SeslSwitchPreferenceScreen>("daily_notification_pref")?.isChecked = viewModel.isDailyNotificationChecked
+                findPreference<SeslSwitchPreferenceScreen>("dailySudokuNotificationEnabled")?.isChecked =
+                    viewModel.isDailyNotificationChecked
             }
 
         override fun onCreatePreferences(
@@ -159,10 +159,6 @@ class SettingsActivity : AppCompatActivity() {
 
         private fun initPreferences() {
             initErrorLimitPreference()
-            initKeepScreenOnPreference()
-            initHighlightRegionalPreference()
-            initHighlightNumberPreference()
-            initAnimationsPreference()
             initDailyNotificationPreference()
             initIntroPreference()
             initExportDataPreference()
@@ -180,36 +176,8 @@ class SettingsActivity : AppCompatActivity() {
             } ?: Log.e(TAG, "error limit Preference not found")
         }
 
-        private fun initKeepScreenOnPreference() {
-            findPreference<SwitchPreferenceCompat>("keep_screen_on_pref")?.apply {
-                isChecked = viewModel.keepScreenOn
-                onNewValue { v: Boolean -> viewModel.keepScreenOn = v }
-            } ?: Log.e(TAG, "keep screen on Preference not found")
-        }
-
-        private fun initHighlightRegionalPreference() {
-            findPreference<SwitchPreferenceCompat>("highlight_regional_pref")?.apply {
-                isChecked = viewModel.highlightRegional
-                onNewValue { v: Boolean -> viewModel.highlightRegional = v }
-            } ?: Log.e(TAG, "regional highlight Preference not found")
-        }
-
-        private fun initHighlightNumberPreference() {
-            findPreference<SwitchPreferenceCompat>("highlight_number_pref")?.apply {
-                isChecked = viewModel.highlightNumber
-                onNewValue { v: Boolean -> viewModel.highlightNumber = v }
-            } ?: Log.e(TAG, "number highlight Preference not found")
-        }
-
-        private fun initAnimationsPreference() {
-            findPreference<SwitchPreferenceCompat>("animations_pref")?.apply {
-                isChecked = viewModel.animationsEnabled
-                onNewValue { v: Boolean -> viewModel.animationsEnabled = v }
-            } ?: Log.e(TAG, "animations Preference not found")
-        }
-
         private fun initDailyNotificationPreference() {
-            findPreference<SeslSwitchPreferenceScreen>("daily_notification_pref")?.apply {
+            findPreference<SeslSwitchPreferenceScreen>("dailySudokuNotificationEnabled")?.apply {
                 isChecked = viewModel.isDailyNotificationChecked
                 setDailyNotificationPrefTime(viewModel.dailySudokuNotificationHour, viewModel.dailySudokuNotificationMinute)
                 onNewValue { applyDailyNotificationToggle(it) }
@@ -234,7 +202,7 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun initIntroPreference() {
-            findPreference<PreferenceScreen>("intro_pref")?.onClick {
+            findPreference<PreferenceScreen>("intro")?.onClick {
                 startActivity(
                     Intent(requireContext(), IntroActivity::class.java).putExtra(IntroActivity.KEY_OPENED_FROM_SETTINGS, true),
                 )
@@ -242,7 +210,7 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun initExportDataPreference() {
-            findPreference<PreferenceScreen>("export_data_pref")?.onClick {
+            findPreference<PreferenceScreen>("exportData")?.onClick {
                 exportActivityResultLauncher.launch(
                     Intent(ACTION_CREATE_DOCUMENT).apply {
                         addCategory(CATEGORY_OPENABLE)
@@ -254,7 +222,7 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun initImportDataPreference() {
-            findPreference<PreferenceScreen>("import_data_pref")?.onClick {
+            findPreference<PreferenceScreen>("importData")?.onClick {
                 AlertDialog
                     .Builder(requireContext())
                     .setTitle(R.string.import_data)
@@ -267,7 +235,7 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun initDeleteInvalidSudokusPreference() {
-            findPreference<PreferenceScreen>("delete_invalid_sudokus_pref")?.onClick {
+            findPreference<PreferenceScreen>("deleteInvalidSudokus")?.onClick {
                 val dialog =
                     AlertDialog
                         .Builder(requireContext())

--- a/app/src/main/java/de/lemke/sudoku/ui/SettingsViewModel.kt
+++ b/app/src/main/java/de/lemke/sudoku/ui/SettingsViewModel.kt
@@ -58,30 +58,6 @@ class SettingsViewModel @Inject constructor(
             userSettings.errorLimit = value
         }
 
-    var keepScreenOn: Boolean
-        get() = userSettings.keepScreenOn
-        set(value) {
-            userSettings.keepScreenOn = value
-        }
-
-    var highlightRegional: Boolean
-        get() = userSettings.highlightRegional
-        set(value) {
-            userSettings.highlightRegional = value
-        }
-
-    var highlightNumber: Boolean
-        get() = userSettings.highlightNumber
-        set(value) {
-            userSettings.highlightNumber = value
-        }
-
-    var animationsEnabled: Boolean
-        get() = userSettings.animationsEnabled
-        set(value) {
-            userSettings.animationsEnabled = value
-        }
-
     val dailySudokuNotificationHour: Int get() = userSettings.dailySudokuNotificationHour
     val dailySudokuNotificationMinute: Int get() = userSettings.dailySudokuNotificationMinute
 

--- a/app/src/main/java/de/lemke/sudoku/ui/SettingsViewModel.kt
+++ b/app/src/main/java/de/lemke/sudoku/ui/SettingsViewModel.kt
@@ -52,12 +52,6 @@ class SettingsViewModel @Inject constructor(
     private val isNotificationPermissionGranted: IsNotificationPermissionGrantedUseCase,
     private val deleteInvalidSudokus: DeleteInvalidSudokusUseCase,
 ) : ViewModel() {
-    var errorLimit: Int
-        get() = userSettings.errorLimit
-        set(value) {
-            userSettings.errorLimit = value
-        }
-
     val dailySudokuNotificationHour: Int get() = userSettings.dailySudokuNotificationHour
     val dailySudokuNotificationMinute: Int get() = userSettings.dailySudokuNotificationMinute
 

--- a/app/src/main/java/de/lemke/sudoku/ui/SudokuActivity.kt
+++ b/app/src/main/java/de/lemke/sudoku/ui/SudokuActivity.kt
@@ -305,7 +305,7 @@ class SudokuActivity : AppCompatActivity() {
             }
             dialog.show()
             applyPlayGamesSync(viewModel.syncPlayGames(sudoku))
-            showInAppReviewIfPossible()
+            showInAppReviewIfPossible(userSettings)
         }
     }
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -19,7 +19,8 @@
 
     <PreferenceCategory android:title="@string/commonutils_general">
         <SwitchPreferenceCompat
-            android:key="keep_screen_on_pref"
+            android:defaultValue="true"
+            android:key="keepScreenOn"
             android:summary="@string/keep_screen_on_summary"
             android:title="@string/keep_screen_on" />
 
@@ -33,19 +34,22 @@
 
     <PreferenceCategory android:title="@string/sudoku">
         <PreferenceScreen
-            android:key="intro_pref"
+            android:key="intro"
             android:summary="@string/intro_title"
             android:title="@string/intro" />
         <SwitchPreferenceCompat
-            android:key="animations_pref"
+            android:defaultValue="true"
+            android:key="animationsEnabled"
             android:summary="@string/animations_summary"
             android:title="@string/animations" />
         <SwitchPreferenceCompat
-            android:key="highlight_regional_pref"
+            android:defaultValue="true"
+            android:key="highlightRegional"
             android:summary="@string/regional_highlight_summary"
             android:title="@string/regional_highlight" />
         <SwitchPreferenceCompat
-            android:key="highlight_number_pref"
+            android:defaultValue="true"
+            android:key="highlightNumber"
             android:summary="@string/number_highlight_summary"
             android:title="@string/number_highlight" />
         <DropDownPreference
@@ -58,7 +62,8 @@
 
     <PreferenceCategory android:title="@string/notifications">
         <SeslSwitchPreferenceScreen
-            android:key="daily_notification_pref"
+            android:defaultValue="true"
+            android:key="dailySudokuNotificationEnabled"
             android:summary="@string/daily_sudoku_notification_channel_description"
             android:title="@string/daily_sudoku_notification_channel_name" />
     </PreferenceCategory>
@@ -68,15 +73,15 @@
         android:title="@string/commonutils_dev_options"
         app:isPreferenceVisible="false">
         <PreferenceScreen
-            android:key="export_data_pref"
+            android:key="exportData"
             android:summary="@string/export_data_summary"
             android:title="@string/export_data" />
         <PreferenceScreen
-            android:key="import_data_pref"
+            android:key="importData"
             android:summary="@string/import_data_summary"
             android:title="@string/import_data" />
         <PreferenceScreen
-            android:key="delete_invalid_sudokus_pref"
+            android:key="deleteInvalidSudokus"
             android:summary="@string/delete_invalid_sudokus_summary"
             android:title="@string/delete_invalid_sudokus" />
         <PreferenceScreen

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -56,7 +56,7 @@
             android:defaultValue="3"
             android:entries="@array/error_limit_entries"
             android:entryValues="@array/error_limit_values"
-            android:key="error_limit_pref"
+            android:key="errorLimit"
             android:title="@string/error_limit" />
     </PreferenceCategory>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 aboutlibraries = "15.2.0"
 async-layout-inflater = "1.1.0"
 bundler = "1.0.4"
-common-utils = "1.2.3"
+common-utils = "1.2.6"
 datastore-preferences = "1.2.1"
 dependency-analysis = "3.19.1"
 detekt = "2.0.0-alpha.6"


### PR DESCRIPTION
## Summary
- Rename every persisting preference's `android:key` to match its `UserSettings` property name (camelCase, no `_pref` suffix), and add `android:defaultValue` where missing (four switches + daily-notification toggle).
- Delete manual `isChecked=`/`onNewValue{}` sync for those switches and their now-dead `SettingsViewModel` pass-through fields — native `Preference` persistence already writes the same key.
- Switch `errorLimit` to a `String`-backed delegate mapped to `Int`, matching `DropDownPreference`'s native String persistence under the unified key (previously a separate, mismatched `Int` delegate). No migration needed — that `Int` delegate never shipped in a release.
- Bump `common-utils` to 1.2.6 and fix the resulting `showInAppReviewIfPossible()` call site.

## Test plan
- [x] `./gradlew spotlessCheck detekt lintDebug assembleDebug testDebugUnitTest` green
- [ ] Fresh install: every switch/dropdown shows its correct default
- [ ] Toggle each preference, relaunch, confirm it persists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Renamed preference keys to match `UserSettings` properties and added default values.
- Removed redundant `SettingsViewModel` state and synchronization.
- Persisted `errorLimit` as a mapped string preference.
- Updated `common-utils` to 1.2.6 and adjusted the in-app review call.
- Automated checks pass. Fresh-install defaults and relaunch persistence require manual verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->