### PR TITLE
test: plan 4 parity closure — use-case tests, progress divide-by-zero, kover ratchet

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -254,8 +254,8 @@ kover {
         variant("debug") {
             verify {
                 rule {
-                    minBound(51, coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.INSTRUCTION)
-                    minBound(22, coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.BRANCH)
+                    minBound(53, coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.INSTRUCTION)
+                    minBound(28, coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.BRANCH)
                 }
             }
         }

--- a/app/src/main/java/de/lemke/sudoku/domain/model/Sudoku.kt
+++ b/app/src/main/java/de/lemke/sudoku/domain/model/Sudoku.kt
@@ -95,7 +95,7 @@ class Sudoku(
     val progress: Int
         get() {
             val total = fields.count { !it.given }
-            return fields.count { !it.given && it.correct } * 100 / total
+            return if (total == 0) 100 else fields.count { !it.given && it.correct } * 100 / total
         }
 
     val timeString: String

--- a/app/src/test/java/de/lemke/sudoku/domain/CalculatePlayGamesSyncUseCaseTest.kt
+++ b/app/src/test/java/de/lemke/sudoku/domain/CalculatePlayGamesSyncUseCaseTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.lemke.sudoku.domain
+
+import de.lemke.sudoku.R
+import de.lemke.sudoku.domain.model.Difficulty.HARD
+import de.lemke.sudoku.domain.model.Difficulty.VERY_EASY
+import de.lemke.sudoku.domain.model.Field
+import de.lemke.sudoku.domain.model.Position
+import de.lemke.sudoku.domain.model.Sudoku
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+private fun testSudoku(
+    difficulty: de.lemke.sudoku.domain.model.Difficulty = VERY_EASY,
+    size: Int = 4,
+    seconds: Int = 0,
+    eraserUsed: Boolean = false,
+    hintsUsed: Int = 0,
+    notesMade: Int = 0,
+    isChecklist: Boolean = false,
+    isReverseChecklist: Boolean = false,
+): Sudoku =
+    Sudoku.create(
+        size = size,
+        difficulty = difficulty,
+        modeLevel = Sudoku.MODE_NORMAL,
+        seconds = seconds,
+        eraserUsed = eraserUsed,
+        hintsUsed = hintsUsed,
+        notesMade = notesMade,
+        isChecklist = isChecklist,
+        isReverseChecklist = isReverseChecklist,
+        fields = mutableListOf(Field(position = Position.create(0, size), solution = 1, value = 1)),
+    )
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CalculatePlayGamesSyncUseCaseTest : ShouldSpec(
+    {
+        val getAllSudokus = mockk<GetAllSudokusUseCase>()
+        val useCase = CalculatePlayGamesSyncUseCase(getAllSudokus, UnconfinedTestDispatcher())
+
+        beforeEach { clearMocks(getAllSudokus) }
+
+        should("only submit base leaderboard scores, no unlocks or increments, when no sudoku just finished") {
+            coEvery { getAllSudokus() } returns listOf(testSudoku())
+
+            val sync = useCase(null)
+
+            sync.leaderboardScores.map { it.first } shouldContain R.string.leaderboard_total_wins
+            sync.leaderboardScores.map { it.first } shouldNotContain R.string.leaderboard_best_time
+            sync.achievementUnlocks shouldBe emptyList()
+            sync.achievementIncrements shouldBe emptyList()
+        }
+
+        should("unlock the no-hints and eraser achievements but not the checklist ones for a plain win") {
+            val won = testSudoku(eraserUsed = true, hintsUsed = 0, notesMade = 0)
+            coEvery { getAllSudokus() } returns listOf(won)
+
+            val unlocks = useCase(won).achievementUnlocks
+
+            unlocks shouldContain R.string.achievement_first_win
+            unlocks shouldContain R.string.achievement_eraser
+            unlocks shouldContain R.string.achievement_no_hints
+            unlocks shouldNotContain R.string.achievement_use_notes
+            unlocks shouldNotContain R.string.achievement_checklist
+        }
+
+        should("unlock the size-specific stopwatch achievement only under its threshold") {
+            val fast = testSudoku(size = 4, seconds = 29)
+            val slow = testSudoku(size = 4, seconds = 31)
+            coEvery { getAllSudokus() } returns listOf(fast, slow)
+
+            useCase(fast).achievementUnlocks shouldContain R.string.achievement_stopwatch_44
+            useCase(slow).achievementUnlocks shouldNotContain R.string.achievement_stopwatch_44
+        }
+
+        should("submit the size+difficulty leaderboard time and win-count scores for the finished sudoku") {
+            val sudoku = testSudoku(size = 9, difficulty = HARD, seconds = 42)
+            coEvery { getAllSudokus() } returns listOf(sudoku)
+
+            val scoreIds = useCase(sudoku).leaderboardScores.map { it.first }
+
+            scoreIds shouldContain R.string.leaderboard_time_99_hard
+            scoreIds shouldContain R.string.leaderboard_wins_99_hard
+        }
+    },
+)

--- a/app/src/test/java/de/lemke/sudoku/domain/CalculateStatisticsUseCaseTest.kt
+++ b/app/src/test/java/de/lemke/sudoku/domain/CalculateStatisticsUseCaseTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.lemke.sudoku.domain
+
+import de.lemke.sudoku.domain.model.Difficulty
+import de.lemke.sudoku.domain.model.Difficulty.EASY
+import de.lemke.sudoku.domain.model.Difficulty.MEDIUM
+import de.lemke.sudoku.domain.model.Field
+import de.lemke.sudoku.domain.model.Position
+import de.lemke.sudoku.domain.model.Sudoku
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+private fun testSudoku(
+    completed: Boolean,
+    difficulty: Difficulty = MEDIUM,
+    size: Int = 9,
+    seconds: Int = 0,
+    errorsMade: Int = 0,
+    hintsUsed: Int = 0,
+    notesMade: Int = 0,
+    eraserUsed: Boolean = false,
+    updated: LocalDateTime = LocalDateTime.now(),
+): Sudoku =
+    Sudoku.create(
+        size = size,
+        difficulty = difficulty,
+        modeLevel = Sudoku.MODE_NORMAL,
+        errorsMade = errorsMade,
+        hintsUsed = hintsUsed,
+        notesMade = notesMade,
+        eraserUsed = eraserUsed,
+        updated = updated,
+        seconds = seconds,
+        fields = mutableListOf(Field(position = Position.create(0, size), solution = 1, value = if (completed) 1 else null)),
+    )
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CalculateStatisticsUseCaseTest : ShouldSpec(
+    {
+        val useCase = CalculateStatisticsUseCase(UnconfinedTestDispatcher())
+
+        should("guard every empty-list aggregate when there are no games") {
+            val stats = useCase(emptyList())
+
+            stats.gamesStarted shouldBe 0
+            stats.gamesCompleted shouldBe 0
+            stats.winRate shouldBe 0
+            stats.averageTime shouldBe -1
+            stats.mostErrors shouldBe 0
+            stats.mostHints shouldBe 0
+            stats.mostNotes shouldBe 0
+            stats.mostGamesStartedDifficulty shouldBe null
+            stats.mostGamesWonDifficulty shouldBe null
+            stats.mostGamesStartedSize shouldBe null
+            stats.mostGamesWonSize shouldBe null
+            stats.currentGameStreak shouldBe 0
+            stats.bestGameStreak shouldBe 0
+        }
+
+        should("round the win rate to the nearest percent") {
+            val sudokus = listOf(testSudoku(completed = true), testSudoku(completed = false), testSudoku(completed = false))
+
+            useCase(sudokus).winRate shouldBe 33
+        }
+
+        should("report averageTime as 0, not -1, once at least one game is completed") {
+            val sudokus = listOf(testSudoku(completed = true, seconds = 10), testSudoku(completed = true, seconds = 20))
+
+            useCase(sudokus).averageTime shouldBe 15
+        }
+
+        should("count the current streak back from the most recently updated game, stopping at the first loss") {
+            val sudokus =
+                listOf(
+                    testSudoku(completed = false, updated = LocalDateTime.now().minusMinutes(3)),
+                    testSudoku(completed = true, updated = LocalDateTime.now().minusMinutes(2)),
+                    testSudoku(completed = true, updated = LocalDateTime.now().minusMinutes(1)),
+                )
+
+            useCase(sudokus).currentGameStreak shouldBe 2
+        }
+
+        should("track the best streak even when it isn't the current one") {
+            val sudokus =
+                listOf(
+                    testSudoku(completed = true, updated = LocalDateTime.now().minusMinutes(4)),
+                    testSudoku(completed = true, updated = LocalDateTime.now().minusMinutes(3)),
+                    testSudoku(completed = false, updated = LocalDateTime.now().minusMinutes(2)),
+                    testSudoku(completed = true, updated = LocalDateTime.now().minusMinutes(1)),
+                )
+
+            val stats = useCase(sudokus)
+            stats.bestGameStreak shouldBe 2
+            stats.currentGameStreak shouldBe 1
+        }
+
+        should("break a tie between equally-played difficulties by first appearance") {
+            val sudokus =
+                listOf(
+                    testSudoku(completed = false, difficulty = EASY),
+                    testSudoku(completed = false, difficulty = MEDIUM),
+                    testSudoku(completed = false, difficulty = EASY),
+                    testSudoku(completed = false, difficulty = MEDIUM),
+                )
+
+            useCase(sudokus).mostGamesStartedDifficulty shouldBe EASY
+        }
+
+        should("report the max errors/hints/notes made across all games, not just completed ones") {
+            val sudokus =
+                listOf(
+                    testSudoku(completed = false, errorsMade = 5, hintsUsed = 1, notesMade = 2),
+                    testSudoku(completed = true, errorsMade = 1, hintsUsed = 4, notesMade = 9),
+                )
+
+            val stats = useCase(sudokus)
+            stats.mostErrors shouldBe 5
+            stats.mostHints shouldBe 4
+            stats.mostNotes shouldBe 9
+        }
+    },
+)

--- a/app/src/test/java/de/lemke/sudoku/domain/GenerateDailySudokuUseCaseTest.kt
+++ b/app/src/test/java/de/lemke/sudoku/domain/GenerateDailySudokuUseCaseTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.lemke.sudoku.domain
+
+import de.lemke.sudoku.domain.model.Difficulty
+import de.lemke.sudoku.domain.model.Field
+import de.lemke.sudoku.domain.model.Sudoku
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GenerateDailySudokuUseCaseTest : ShouldSpec(
+    {
+        val generateFields = mockk<GenerateFieldsUseCase>()
+        val fixedInstant = Instant.parse("2026-02-15T10:00:00Z")
+        val clock = mockk<Clock>()
+        val useCase = GenerateDailySudokuUseCase(generateFields, clock, UnconfinedTestDispatcher())
+
+        should("mark the sudoku as daily mode, stamp created from the injected clock, and pick a supported difficulty") {
+            every { clock.instant() } returns fixedInstant
+            every { clock.zone } returns ZoneOffset.UTC
+            coEvery { generateFields(9, any()) } returns mutableListOf<Field>()
+
+            val sudoku = useCase(9)
+
+            sudoku.modeLevel shouldBe Sudoku.MODE_DAILY
+            sudoku.created shouldBe LocalDateTime.ofInstant(fixedInstant, ZoneOffset.UTC)
+            sudoku.difficulty shouldBeIn listOf(Difficulty.VERY_EASY, Difficulty.EASY, Difficulty.MEDIUM, Difficulty.HARD)
+        }
+    },
+)

--- a/app/src/test/java/de/lemke/sudoku/domain/GenerateSudokuLevelUseCaseTest.kt
+++ b/app/src/test/java/de/lemke/sudoku/domain/GenerateSudokuLevelUseCaseTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.lemke.sudoku.domain
+
+import de.lemke.sudoku.domain.model.Difficulty.EASY
+import de.lemke.sudoku.domain.model.Difficulty.EXPERT
+import de.lemke.sudoku.domain.model.Difficulty.HARD
+import de.lemke.sudoku.domain.model.Difficulty.MEDIUM
+import de.lemke.sudoku.domain.model.Difficulty.VERY_EASY
+import de.lemke.sudoku.domain.model.Field
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GenerateSudokuLevelUseCaseTest : ShouldSpec(
+    {
+        val generateFields = mockk<GenerateFieldsUseCase>()
+        val useCase = GenerateSudokuLevelUseCase(generateFields, UnconfinedTestDispatcher())
+
+        beforeEach { clearMocks(generateFields) }
+
+        should("map every level-threshold boundary to its difficulty") {
+            val cases =
+                mapOf(
+                    1 to VERY_EASY,
+                    30 to VERY_EASY,
+                    31 to EASY,
+                    100 to EASY,
+                    101 to MEDIUM,
+                    200 to MEDIUM,
+                    201 to HARD,
+                    500 to HARD,
+                    501 to EXPERT,
+                )
+
+            cases.forEach { (level, expectedDifficulty) ->
+                coEvery { generateFields(9, expectedDifficulty) } returns mutableListOf<Field>()
+
+                val sudoku = useCase(9, level)
+
+                sudoku.difficulty shouldBe expectedDifficulty
+                sudoku.modeLevel shouldBe level
+            }
+        }
+    },
+)

--- a/app/src/test/java/de/lemke/sudoku/domain/GenerateSudokuUseCaseTest.kt
+++ b/app/src/test/java/de/lemke/sudoku/domain/GenerateSudokuUseCaseTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.lemke.sudoku.domain
+
+import de.lemke.sudoku.domain.model.Difficulty.HARD
+import de.lemke.sudoku.domain.model.Field
+import de.lemke.sudoku.domain.model.Sudoku
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GenerateSudokuUseCaseTest : ShouldSpec(
+    {
+        val generateFields = mockk<GenerateFieldsUseCase>()
+        val useCase = GenerateSudokuUseCase(generateFields, UnconfinedTestDispatcher())
+
+        should("pass size/difficulty through to GenerateFieldsUseCase and mark the sudoku as normal mode") {
+            val fields = mutableListOf<Field>()
+            coEvery { generateFields(9, HARD) } returns fields
+
+            val sudoku = useCase(9, HARD)
+
+            sudoku.size shouldBe 9
+            sudoku.difficulty shouldBe HARD
+            sudoku.modeLevel shouldBe Sudoku.MODE_NORMAL
+            sudoku.fields shouldBe fields
+        }
+    },
+)

--- a/app/src/test/java/de/lemke/sudoku/domain/ObserveDailySudokusUseCaseTest.kt
+++ b/app/src/test/java/de/lemke/sudoku/domain/ObserveDailySudokusUseCaseTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.lemke.sudoku.domain
+
+import app.cash.turbine.test
+import de.lemke.commonutils.data.FakeSharedPreferences
+import de.lemke.sudoku.data.UserSettings
+import de.lemke.sudoku.data.database.SudokusRepository
+import de.lemke.sudoku.domain.model.Difficulty.VERY_EASY
+import de.lemke.sudoku.domain.model.Field
+import de.lemke.sudoku.domain.model.Position
+import de.lemke.sudoku.domain.model.Sudoku
+import de.lemke.sudoku.domain.model.SudokuListItem
+import de.lemke.sudoku.domain.model.monthAndYear
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+private fun dailySudoku(
+    created: LocalDateTime,
+    completed: Boolean,
+): Sudoku =
+    Sudoku.create(
+        size = 9,
+        difficulty = VERY_EASY,
+        modeLevel = Sudoku.MODE_DAILY,
+        created = created,
+        fields = mutableListOf(Field(position = Position.create(0, 9), solution = 1, value = if (completed) 1 else null)),
+    )
+
+private fun List<SudokuListItem>.shape(): List<Pair<String, String>> =
+    map {
+        when (it) {
+            is SudokuListItem.SudokuItem -> "item" to it.label
+            is SudokuListItem.SeparatorItem -> "separator" to it.label
+        }
+    }
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveDailySudokusUseCaseTest : ShouldSpec(
+    {
+        val sudokusRepository = mockk<SudokusRepository>()
+        lateinit var userSettings: UserSettings
+        lateinit var useCase: ObserveDailySudokusUseCase
+
+        val today = LocalDateTime.of(2026, 2, 15, 10, 0)
+        val todayDate = today.toLocalDate()
+        val completedThisMonth = dailySudoku(created = LocalDateTime.of(2026, 2, 5, 9, 0), completed = true)
+        val uncompletedToday = dailySudoku(created = today, completed = false)
+        val uncompletedLastMonth = dailySudoku(created = LocalDateTime.of(2026, 1, 20, 9, 0), completed = false)
+
+        beforeEach {
+            userSettings = UserSettings(FakeSharedPreferences(), CoroutineScope(UnconfinedTestDispatcher()))
+            useCase = ObserveDailySudokusUseCase(sudokusRepository, userSettings, UnconfinedTestDispatcher())
+            every { sudokusRepository.observeDailySudokus() } returns
+                flowOf(listOf(completedThisMonth, uncompletedToday, uncompletedLastMonth))
+        }
+
+        should("show every daily sudoku, including old uncompleted ones, when dailyShowUncompleted is on") {
+            userSettings.dailyShowUncompleted = true
+
+            useCase(todayDate).test {
+                awaitItem().shape() shouldBe
+                    listOf(
+                        "separator" to completedThisMonth.created.monthAndYear,
+                        "item" to completedThisMonth.created.monthAndYear,
+                        "item" to uncompletedToday.created.monthAndYear,
+                        "separator" to uncompletedLastMonth.created.monthAndYear,
+                        "item" to uncompletedLastMonth.created.monthAndYear,
+                    )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        should("hide old uncompleted daily sudokus but keep today's in-progress one when dailyShowUncompleted is off") {
+            userSettings.dailyShowUncompleted = false
+
+            useCase(todayDate).test {
+                awaitItem().shape() shouldBe
+                    listOf(
+                        "separator" to completedThisMonth.created.monthAndYear,
+                        "item" to completedThisMonth.created.monthAndYear,
+                        "item" to uncompletedToday.created.monthAndYear,
+                    )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        should("re-filter when dailyShowUncompleted flips while being observed") {
+            userSettings.dailyShowUncompleted = false
+
+            useCase(todayDate).test {
+                awaitItem().shape().size shouldBe 3
+
+                userSettings.dailyShowUncompleted = true
+
+                awaitItem().shape().size shouldBe 5
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    },
+)

--- a/app/src/test/java/de/lemke/sudoku/domain/ObserveSudokuHistoryUseCaseTest.kt
+++ b/app/src/test/java/de/lemke/sudoku/domain/ObserveSudokuHistoryUseCaseTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.lemke.sudoku.domain
+
+import app.cash.turbine.test
+import de.lemke.sudoku.domain.model.Difficulty.VERY_EASY
+import de.lemke.sudoku.domain.model.Field
+import de.lemke.sudoku.domain.model.Position
+import de.lemke.sudoku.domain.model.Sudoku
+import de.lemke.sudoku.domain.model.SudokuListItem
+import de.lemke.sudoku.domain.model.dateFormatShort
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+private fun sudokuUpdatedAt(updated: LocalDateTime): Sudoku =
+    Sudoku.create(
+        size = 4,
+        difficulty = VERY_EASY,
+        modeLevel = Sudoku.MODE_NORMAL,
+        updated = updated,
+        fields = mutableListOf(Field(position = Position.create(0, 4), solution = 1, value = 1)),
+    )
+
+private fun List<SudokuListItem>.shape(): List<Pair<String, String>> =
+    map {
+        when (it) {
+            is SudokuListItem.SudokuItem -> "item" to it.label
+            is SudokuListItem.SeparatorItem -> "separator" to it.label
+        }
+    }
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveSudokuHistoryUseCaseTest : ShouldSpec(
+    {
+        val observeAllNormalSudokus = mockk<ObserveAllNormalSudokusUseCase>()
+        val useCase = ObserveSudokuHistoryUseCase(observeAllNormalSudokus, UnconfinedTestDispatcher())
+        val day1 = LocalDateTime.of(2026, 1, 1, 10, 0)
+        val day2 = LocalDateTime.of(2026, 1, 2, 10, 0)
+        val label1 = day1.dateFormatShort
+        val label2 = day2.dateFormatShort
+
+        should("emit an empty list when there is no history") {
+            every { observeAllNormalSudokus() } returns flowOf(emptyList())
+
+            useCase().test {
+                awaitItem() shouldBe emptyList()
+                awaitComplete()
+            }
+        }
+
+        should("insert exactly one separator when every game is on the same day") {
+            every { observeAllNormalSudokus() } returns flowOf(listOf(sudokuUpdatedAt(day1), sudokuUpdatedAt(day1)))
+
+            useCase().test {
+                awaitItem().shape() shouldBe
+                    listOf(
+                        "separator" to label1,
+                        "item" to label1,
+                        "item" to label1,
+                    )
+                awaitComplete()
+            }
+        }
+
+        should("insert a new separator when the day changes mid-list") {
+            every { observeAllNormalSudokus() } returns
+                flowOf(listOf(sudokuUpdatedAt(day1), sudokuUpdatedAt(day2), sudokuUpdatedAt(day2)))
+
+            useCase().test {
+                awaitItem().shape() shouldBe
+                    listOf(
+                        "separator" to label1,
+                        "item" to label1,
+                        "separator" to label2,
+                        "item" to label2,
+                        "item" to label2,
+                    )
+                awaitComplete()
+            }
+        }
+    },
+)

--- a/app/src/test/java/de/lemke/sudoku/domain/model/SudokuTest.kt
+++ b/app/src/test/java/de/lemke/sudoku/domain/model/SudokuTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.lemke.sudoku.domain.model
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+
+class SudokuTest : ShouldSpec(
+    {
+        should("report 100% progress instead of throwing when every field is given") {
+            val sudoku =
+                Sudoku.create(
+                    size = 4,
+                    difficulty = Difficulty.VERY_EASY,
+                    modeLevel = Sudoku.MODE_NORMAL,
+                    fields =
+                        mutableListOf(
+                            Field(position = Position.create(0, 4), solution = 1, value = 1, given = true),
+                            Field(position = Position.create(1, 4), solution = 2, value = 2, given = true),
+                        ),
+                )
+
+            sudoku.progress shouldBe 100
+        }
+
+        should("compute progress as the percentage of non-given fields solved correctly") {
+            val sudoku =
+                Sudoku.create(
+                    size = 4,
+                    difficulty = Difficulty.VERY_EASY,
+                    modeLevel = Sudoku.MODE_NORMAL,
+                    fields =
+                        mutableListOf(
+                            Field(position = Position.create(0, 4), solution = 1, value = 1, given = true),
+                            Field(position = Position.create(1, 4), solution = 2, value = 2, given = false),
+                            Field(position = Position.create(2, 4), solution = 3, value = null, given = false),
+                        ),
+                )
+
+            sudoku.progress shouldBe 50
+        }
+    },
+)


### PR DESCRIPTION
## Summary
- Add tests for the 7 highest-value untested use cases (`CalculateStatisticsUseCase`, `CalculatePlayGamesSyncUseCase`, `ObserveSudokuHistoryUseCase`, `ObserveDailySudokusUseCase`, `GenerateSudokuLevelUseCase`, `GenerateSudokuUseCase`, `GenerateDailySudokuUseCase`); remaining untested use cases excluded with reason (see first commit message) — welded to Android UI/system dialogs, unseeded solver, or not worth the Robolectric cost.
- Fix `Sudoku.progress` throwing `ArithmeticException` on an all-given board (reachable via a malformed/adversarial import), guarded with a test.
- Ratchet the Kover floor from 51%/22% to 53%/28% (instruction/branch) to match the measured coverage after the above.

## Test plan
- [x] `./gradlew spotlessCheck detekt`
- [x] `./gradlew lintDebug`
- [x] `./gradlew testDebugUnitTest verifyRoborazziDebug koverVerifyDebug`
- [x] `./gradlew assembleDebug`
- [x] `./gradlew pixel9Api35DebugAndroidTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vvo65tsNYCxuNKURWdNr5V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added tests for seven previously untested use cases.
- Fixed `Sudoku.progress` for all-given boards.
- Increased Kover thresholds to 53% instruction and 28% branch coverage.
- All required checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->