### PR TITLE
perf: add baseline profile + macrobenchmarks

### DIFF
--- a/.github/workflows/baseline-profile.yml
+++ b/.github/workflows/baseline-profile.yml
@@ -1,0 +1,47 @@
+name: Baseline Profile
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 1 */3 *' # quarterly: Jan/Apr/Jul/Oct 1st at 03:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Set up JDK
+        uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Generate baseline profile
+        run: |
+          chmod +x ./gradlew
+          ./gradlew :app:generateBaselineProfile \
+            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect --stacktrace
+        env:
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Upload baseline profile
+        uses: actions/upload-artifact@v7
+        with:
+          name: baseline-profile
+          path: |
+            app/src/release/generated/baselineProfiles/baseline-prof.txt
+            app/src/release/generated/baselineProfiles/startup-prof.txt

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -173,12 +173,14 @@ dependencies {
     implementation(libs.documentfile)
     implementation(libs.sudoku)
     implementation(libs.play.services.games)
-    implementation(libs.profileinstaller)
     implementation(libs.bundles.json)
     implementation(libs.bundles.room)
     implementation(libs.hilt.android)
     ksp(libs.room.compiler)
     ksp(libs.hilt.compiler)
+
+    implementation(libs.profileinstaller)
+    baselineProfile(project(":benchmarks"))
     debugImplementation(libs.leakcanary)
 
     testImplementation(libs.konsist)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     alias(libs.plugins.kover)
     alias(libs.plugins.android.junit)
     alias(libs.plugins.roborazzi)
+    alias(libs.plugins.baselineprofile)
 }
 
 fun String.toEnvVarStyle(): String = replace(Regex("([a-z])([A-Z])"), "$1_$2").uppercase()
@@ -142,6 +143,27 @@ android {
         animationsDisabled = true
     }
 }
+
+androidComponents {
+    // Both benchmark build types must skip OOBE
+    listOf("nonMinifiedRelease", "benchmarkRelease").forEach { buildType ->
+        onVariants(selector().withBuildType(buildType)) { variant ->
+            variant.buildConfigFields!!.put(
+                "FIRST_RUN_SKIPPABLE",
+                com.android.build.api.variant.BuildConfigField(
+                    "boolean",
+                    "true",
+                    "Allow benchmarks to skip the first-run chain",
+                ),
+            )
+        }
+    }
+}
+
+baselineProfile {
+    dexLayoutOptimization = true
+}
+
 dependencies {
     implementation(libs.oneui.design)
     implementation(libs.oneui.icons)
@@ -151,6 +173,7 @@ dependencies {
     implementation(libs.documentfile)
     implementation(libs.sudoku)
     implementation(libs.play.services.games)
+    implementation(libs.profileinstaller)
     implementation(libs.bundles.json)
     implementation(libs.bundles.room)
     implementation(libs.hilt.android)

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    alias(libs.plugins.android.test)
+    alias(libs.plugins.baselineprofile)
+}
+
+android {
+    namespace = "de.lemke.sudoku.benchmarks"
+    compileSdk {
+        version = release(37) { minorApiLevel = 1 }
+    }
+    defaultConfig {
+        minSdk = 28
+        targetSdk = 37
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+    targetProjectPath = ":app"
+    experimentalProperties["android.experimental.self-instrumenting"] = true
+}
+
+dependencies {
+    implementation(libs.benchmark.macro.junit4)
+    implementation(libs.uiautomator)
+    implementation(libs.androidx.test.ext.junit)
+    implementation(libs.androidx.test.runner)
+}
+
+baselineProfile {
+    @Suppress("UnstableApiUsage")
+    enableEmulatorDisplay = false
+    managedDevices.clear()
+    managedDevices += "pixel9Api35"
+    useConnectedDevices = false
+}

--- a/benchmarks/src/main/AndroidManifest.xml
+++ b/benchmarks/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/BaselineProfileGenerator.kt
+++ b/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/BaselineProfileGenerator.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.sudoku.benchmarks
+
+import androidx.benchmark.macro.MacrobenchmarkScope
+import androidx.benchmark.macro.junit4.BaselineProfileRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.uiautomator.By
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class BaselineProfileGenerator {
+    @get:Rule
+    val rule = BaselineProfileRule()
+
+    // Startup profile drives dex layout optimization, so it must stay limited to the actual
+    // cold-start path — a secondary screen here would bloat startup-prof.txt with non-startup code.
+    @Test
+    fun startup() =
+        rule.collect(
+            packageName = PACKAGE_NAME,
+            includeInStartupProfile = true,
+        ) {
+            pressHome()
+            startActivityAndSkipOnboarding()
+        }
+
+    @Test
+    fun generate() =
+        rule.collect(
+            packageName = PACKAGE_NAME,
+            stableIterations = 3,
+            maxIterations = 10,
+        ) {
+            pressHome()
+            startActivityAndSkipOnboarding()
+            navigateToLevelsAndBack()
+        }
+}
+
+private fun MacrobenchmarkScope.navigateToLevelsAndBack() {
+    device.waitAndFindObject(By.res(PACKAGE_NAME, "levelsButton"), TIMEOUT_MS).click()
+    device.waitAndFindObject(By.res(PACKAGE_NAME, "viewPagerLevel"), TIMEOUT_MS)
+    device.pressBack()
+    device.waitForIdle()
+}

--- a/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/BaselineProfileGenerator.kt
+++ b/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/BaselineProfileGenerator.kt
@@ -52,12 +52,22 @@ class BaselineProfileGenerator {
             pressHome()
             startActivityAndSkipOnboarding()
             navigateToLevelsAndBack()
+            navigateToNewGameAndBack()
         }
 }
 
 private fun MacrobenchmarkScope.navigateToLevelsAndBack() {
     device.waitAndFindObject(By.res(PACKAGE_NAME, "levelsButton"), TIMEOUT_MS).click()
     device.waitAndFindObject(By.res(PACKAGE_NAME, "viewPagerLevel"), TIMEOUT_MS)
+    device.pressBack()
+    device.waitForIdle()
+}
+
+// Covers actual gameplay (domain model, game_recycler adapter, number input) — the code path
+// levelsButton alone never touches.
+private fun MacrobenchmarkScope.navigateToNewGameAndBack() {
+    device.waitAndFindObject(By.res(PACKAGE_NAME, "newGameButton"), TIMEOUT_MS).click()
+    device.waitAndFindObject(By.res(PACKAGE_NAME, "game_recycler"), GENERATION_TIMEOUT_MS)
     device.pressBack()
     device.waitForIdle()
 }

--- a/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/BenchmarkMetrics.kt
+++ b/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/BenchmarkMetrics.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.sudoku.benchmarks
+
+import androidx.benchmark.macro.ExperimentalMetricApi
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.TraceSectionMetric
+
+object BenchmarkMetrics {
+    @OptIn(ExperimentalMetricApi::class)
+    val jitCompilationMetric = TraceSectionMetric("JIT compiling %", label = "JIT compilation")
+
+    @OptIn(ExperimentalMetricApi::class)
+    val classInitMetric = TraceSectionMetric("L%/%;", label = "ClassInit")
+
+    @OptIn(ExperimentalMetricApi::class)
+    val allMetrics = listOf(StartupTimingMetric(), jitCompilationMetric, classInitMetric)
+}

--- a/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/BenchmarkUtils.kt
+++ b/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/BenchmarkUtils.kt
@@ -25,6 +25,10 @@ import androidx.test.uiautomator.Until
 const val PACKAGE_NAME = "de.lemke.sudoku"
 const val TIMEOUT_MS = 5_000L
 
+// Sudoku generation (de.sfuhrm:sudoku) runs synchronously before SudokuActivity launches —
+// duration varies with size/difficulty, so this hop needs more headroom than a plain nav wait.
+const val GENERATION_TIMEOUT_MS = 15_000L
+
 // Must match de.lemke.commonutils.EXTRA_SKIP_ONBOARDING — cannot import from test module
 const val EXTRA_SKIP_ONBOARDING = "commonUtilsSkipOnboarding"
 

--- a/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/BenchmarkUtils.kt
+++ b/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/BenchmarkUtils.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.sudoku.benchmarks
+
+import androidx.benchmark.macro.MacrobenchmarkScope
+import androidx.test.uiautomator.BySelector
+import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject2
+import androidx.test.uiautomator.Until
+
+const val PACKAGE_NAME = "de.lemke.sudoku"
+const val TIMEOUT_MS = 5_000L
+
+// Must match de.lemke.commonutils.EXTRA_SKIP_ONBOARDING — cannot import from test module
+const val EXTRA_SKIP_ONBOARDING = "commonUtilsSkipOnboarding"
+
+fun MacrobenchmarkScope.startActivityAndSkipOnboarding() =
+    startActivityAndWait { it.putExtra(EXTRA_SKIP_ONBOARDING, true) }
+
+fun UiDevice.flingElementDownUp(element: UiObject2) {
+    element.setGestureMargin(displayWidth / 5)
+    element.fling(Direction.DOWN)
+    waitForIdle()
+    element.fling(Direction.UP)
+}
+
+fun UiDevice.waitAndFindObject(selector: BySelector, timeout: Long): UiObject2 =
+    checkNotNull(wait(Until.findObject(selector), timeout)) {
+        "Element not found on screen in ${timeout}ms (selector=$selector)"
+    }

--- a/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/ScrollBenchmark.kt
+++ b/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/ScrollBenchmark.kt
@@ -46,9 +46,11 @@ class ScrollBenchmark {
                 pressHome()
                 startActivityAndSkipOnboarding()
                 device.waitAndFindObject(By.res(PACKAGE_NAME, "levelsButton"), TIMEOUT_MS).click()
+                // sudokuLevelsRecycler stays GONE until InitSudokuLevelUseCase finishes generating levels on a
+                // fresh install, and the separator row has no item_text — wait on a real level row's own id.
                 device.waitAndFindObject(
-                    By.res(PACKAGE_NAME, "sudokuLevelsRecycler").hasDescendant(By.clazz("android.widget.TextView")),
-                    TIMEOUT_MS,
+                    By.res(PACKAGE_NAME, "sudokuLevelsRecycler").hasDescendant(By.res(PACKAGE_NAME, "item_text")),
+                    GENERATION_TIMEOUT_MS,
                 )
             },
         ) {

--- a/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/ScrollBenchmark.kt
+++ b/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/ScrollBenchmark.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.sudoku.benchmarks
+
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.uiautomator.By
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class ScrollBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun scrollBaselineProfile() = scroll(CompilationMode.Partial())
+
+    private fun scroll(compilationMode: CompilationMode) =
+        benchmarkRule.measureRepeated(
+            packageName = PACKAGE_NAME,
+            metrics = listOf(FrameTimingMetric()),
+            compilationMode = compilationMode,
+            iterations = 10,
+            startupMode = StartupMode.WARM,
+            setupBlock = {
+                pressHome()
+                startActivityAndSkipOnboarding()
+                device.waitAndFindObject(By.res(PACKAGE_NAME, "levelsButton"), TIMEOUT_MS).click()
+                device.waitAndFindObject(
+                    By.res(PACKAGE_NAME, "sudokuLevelsRecycler").hasDescendant(By.clazz("android.widget.TextView")),
+                    TIMEOUT_MS,
+                )
+            },
+        ) {
+            val recycler =
+                checkNotNull(device.findObject(By.res(PACKAGE_NAME, "sudokuLevelsRecycler"))) { "sudokuLevelsRecycler not found" }
+            device.flingElementDownUp(recycler)
+        }
+}

--- a/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/ScrollBenchmark.kt
+++ b/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/ScrollBenchmark.kt
@@ -30,7 +30,11 @@ import org.junit.runner.RunWith
 // puzzles, which this black-box UI test can't do). History instead grows just by starting games
 // — TabSudokuViewModel.createNewSudoku saves immediately, before SudokuActivity even opens — so
 // seed that list directly instead.
-private const val HISTORY_SEED_COUNT = 8
+//
+// All seeded rows land under one date separator, and each two-line row is
+// ?android:listPreferredItemHeight (~72dp) tall — a tall device like pixel9Api35 fits ~10-12 rows
+// without scrolling at all, so the count needs real margin above that, not just >1.
+private const val HISTORY_SEED_COUNT = 20
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest

--- a/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/ScrollBenchmark.kt
+++ b/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/ScrollBenchmark.kt
@@ -26,6 +26,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+// Level list stays at exactly 1 row on a fresh install (levels only accumulate by finishing
+// puzzles, which this black-box UI test can't do). History instead grows just by starting games
+// — TabSudokuViewModel.createNewSudoku saves immediately, before SudokuActivity even opens — so
+// seed that list directly instead.
+private const val HISTORY_SEED_COUNT = 8
+
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class ScrollBenchmark {
@@ -45,17 +51,21 @@ class ScrollBenchmark {
             setupBlock = {
                 pressHome()
                 startActivityAndSkipOnboarding()
-                device.waitAndFindObject(By.res(PACKAGE_NAME, "levelsButton"), TIMEOUT_MS).click()
-                // sudokuLevelsRecycler stays GONE until InitSudokuLevelUseCase finishes generating levels on a
-                // fresh install, and the separator row has no item_text — wait on a real level row's own id.
+                repeat(HISTORY_SEED_COUNT) {
+                    device.waitAndFindObject(By.res(PACKAGE_NAME, "newGameButton"), TIMEOUT_MS).click()
+                    device.waitAndFindObject(By.res(PACKAGE_NAME, "game_recycler"), GENERATION_TIMEOUT_MS)
+                    device.pressBack()
+                    device.waitForIdle()
+                }
+                device.waitAndFindObject(By.res(PACKAGE_NAME, "history_dest"), TIMEOUT_MS).click()
                 device.waitAndFindObject(
-                    By.res(PACKAGE_NAME, "sudokuLevelsRecycler").hasDescendant(By.res(PACKAGE_NAME, "item_text")),
-                    GENERATION_TIMEOUT_MS,
+                    By.res(PACKAGE_NAME, "sudokuHistoryList").hasDescendant(By.res(PACKAGE_NAME, "item_text")),
+                    TIMEOUT_MS,
                 )
             },
         ) {
             val recycler =
-                checkNotNull(device.findObject(By.res(PACKAGE_NAME, "sudokuLevelsRecycler"))) { "sudokuLevelsRecycler not found" }
+                checkNotNull(device.findObject(By.res(PACKAGE_NAME, "sudokuHistoryList"))) { "sudokuHistoryList not found" }
             device.flingElementDownUp(recycler)
         }
 }

--- a/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/StartupBenchmark.kt
+++ b/benchmarks/src/main/java/de/lemke/sudoku/benchmarks/StartupBenchmark.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.lemke.sudoku.benchmarks
+
+import androidx.benchmark.macro.BaselineProfileMode.Disable
+import androidx.benchmark.macro.BaselineProfileMode.Require
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.StartupMode.COLD
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class StartupBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun startupNoCompilation() = startup(CompilationMode.None())
+
+    @Test
+    fun startupBaselineProfileDisabled() =
+        startup(CompilationMode.Partial(baselineProfileMode = Disable, warmupIterations = 1))
+
+    @Test
+    fun startupBaselineProfile() = startup(CompilationMode.Partial(baselineProfileMode = Require))
+
+    @Test
+    fun startupFullCompilation() = startup(CompilationMode.Full())
+
+    private fun startup(compilationMode: CompilationMode) =
+        benchmarkRule.measureRepeated(
+            packageName = PACKAGE_NAME,
+            metrics = BenchmarkMetrics.allMetrics,
+            compilationMode = compilationMode,
+            iterations = 15,
+            startupMode = COLD,
+            setupBlock = { pressHome() },
+        ) {
+            startActivityAndSkipOnboarding()
+        }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,8 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.android.test) apply false
+    alias(libs.plugins.baselineprofile) apply false
     alias(libs.plugins.spotless)
     alias(libs.plugins.dependency.analysis)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ androidx-test-rules = "1.7.0"
 androidx-test-runner = "1.7.0"
 arch-core-testing = "2.2.0"
 async-layout-inflater = "1.1.0"
+benchmark-macro = "1.5.0"
 bundler = "1.0.4"
 common-utils = "1.2.6"
 coroutines-test = "1.11.0"
@@ -36,12 +37,14 @@ mockk = "1.14.11"
 oneui-design = "0.9.19+oneui8"
 oneui-icons = "1.1.0"
 play-services-games = "22.0.0"
+profileinstaller = "1.4.1"
 robolectric = "4.17"
 roborazzi = "1.74.0"
 room = "2.8.5"
 spotless = "8.10.2"
 sudoku = "5.3.1"
 turbine = "1.2.1"
+uiautomator = "2.4.0"
 
 [libraries]
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
@@ -53,6 +56,7 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
 arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "arch-core-testing" }
 async-layout-inflater = { module = "androidx.asynclayoutinflater:asynclayoutinflater", version.ref = "async-layout-inflater" }
+benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "benchmark-macro" }
 bundler = { module = "com.github.skydoves:bundler", version.ref = "bundler" }
 common-utils = { module = "io.github.lemkinator:common-utils", version.ref = "common-utils" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-test" }
@@ -77,6 +81,7 @@ mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 oneui-design = { module = "io.github.tribalfs:oneui-design", version.ref = "oneui-design" }
 oneui-icons = { module = "io.github.oneuiproject:icons", version.ref = "oneui-icons" }
 play-services-games = { module = "com.google.android.gms:play-services-games-v2", version.ref = "play-services-games" }
+profileinstaller = { module = "androidx.profileinstaller:profileinstaller", version.ref = "profileinstaller" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version.ref = "roborazzi" }
 roborazzi-rule = { module = "io.github.takahirom.roborazzi:roborazzi-junit-rule", version.ref = "roborazzi" }
@@ -85,11 +90,14 @@ room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 sudoku = { module = "de.sfuhrm:sudoku", version.ref = "sudoku" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
 
 [plugins]
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
 android-application = { id = "com.android.application", version.ref = "gradle" }
 android-junit = { id = "de.mannodermaus.android-junit", version.ref = "junit-android-framework" }
+android-test = { id = "com.android.test", version.ref = "gradle" }
+baselineprofile = { id = "androidx.baselineprofile", version.ref = "benchmark-macro" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,3 +29,4 @@ plugins {
 
 rootProject.name = "Sudoku"
 include(":app")
+include(":benchmarks")


### PR DESCRIPTION
## Summary
- Adds a `:benchmarks` (`com.android.test`) module with `BaselineProfileGenerator`, `StartupBenchmark` (4 compilation modes), and `ScrollBenchmark`.
- Wires `androidx.baselineprofile` + `profileinstaller` into `:app`; `nonMinifiedRelease`/`benchmarkRelease` variants get `FIRST_RUN_SKIPPABLE=true` so benchmarks skip onboarding.
- Root `build.gradle.kts` now declares `android-test`/`baselineprofile` plugins `apply false` alongside `android-application` — AGP resolves `com.android.test` off the same classpath entry and fails otherwise ("plugin already on classpath with unknown version").
- Baseline profile generation itself runs via a new on-demand/quarterly GitHub Actions workflow (`baseline-profile.yml`), not gated on this PR.
- Critical-journey walk covers both the level browser and actual gameplay (`newGameButton` → `SudokuActivity`), since gameplay is where the domain model / adapter / input-handling code actually runs.

## Test plan
- [x] `./gradlew spotlessCheck detekt` (check-formatting)
- [x] `./gradlew lintDebug`
- [x] `./gradlew testDebugUnitTest koverVerifyDebug verifyRoborazziDebug`
- [x] `./gradlew :app:assembleRelease` — verified `assets/dexopt/baseline.prof` present in the APK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJRWVP8mBb9mfnP6ZtRCKg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds Android baseline profile support and macrobenchmarks.

- Adds the `:benchmarks` module with startup, scroll, and baseline profile tests.
- Integrates `androidx.baselineprofile` and `profileinstaller`.
- Skips onboarding in benchmark variants.
- Adds quarterly or manual baseline profile generation through GitHub Actions.
- Extends profiling through level browsing, gameplay, and seeded history scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->